### PR TITLE
Separate listeners per namespace

### DIFF
--- a/NetworkPolicy/k8s-listener.py
+++ b/NetworkPolicy/k8s-listener.py
@@ -397,6 +397,7 @@ def process_namespaces(s):
         obj = simplejson.loads(s)
     except Exception as e:
         logging.warning("Failed to parse %s as json %s" %(s,e))
+        return
 
     op = obj.get("type")
     if not op:
@@ -416,10 +417,12 @@ def process_namespaces(s):
     ns_name = meta.get("name")
     if not ns_name:
         logging.warning("Failed to parse namespace name out of %s" % obj)
+        return
 
     ns_uid = meta.get("uid")
     if not ns_uid:
         logging.warning("Failed to parse namespace uid out of %s" % obj)
+        return
 
     logging.debug("In process_namespace:: operation=%s" % op)
     if op == 'ADDED':

--- a/NetworkPolicy/k8s-listener.py
+++ b/NetworkPolicy/k8s-listener.py
@@ -519,7 +519,6 @@ def process(s, uid_by_ns, pd_by_uid):
     if op == 'NS_CLEANUP':
         ns = obj.get("namespace")
         for uid in uid_by_ns[ns]:
-            # TODO
             dispatch_orders('DELETED', pd_by_uid[uid])
             del pd_by_uid[uid]
             uid_by_ns[ns].remove(uid)


### PR DESCRIPTION
# Design review request

This listener will watch for kubernetes namespace ADD/DELETE events and manage pool of NetworkPolicy listeners, one per namespace.

There is one use-case not addressed currently and i'd like to hear some opinions about it.
## Case: clean up policies on namespace DELETE event

Consider workflow:
- Namespace **dev** is created
- Policy **pol-dev** is created in the namespace
- Namespace is deleted
- Policy left in place and can not be deleted any more
  That feels like a bad state to be in. However, there are following concerns regarding cleanup routine.

In order to cleanup network policies associated with namespace we need a list of this policies, naturally such list could easily be maintained inside subprocess associated with the namespace. Then there are 2 possible workflows: either fetch this list from subprocess before terminating it or make subprocess to cleanup this list for himself. 

Fetching NP list from the subprocess can be done on demand, which can take up to timeout seconds (5 min), or it can be prepared upfront but then queue size gets ridiculously large. 

Putting cleanup routine in subprocess itself requires analog of `defer` function implementation by intercepting os.TERM signal. This looks error prone and overall bad idea.

So far best solution i see is to separate listener and manager in different subprocesses, making them communicate via queue. One reason i don't do right away is because this script is 700 lines already and it's really outlived itself.

So, unless someone points me to better way to cleanup policies i suggest we leave it as it is and address proper cleanup during Golang porting phase.  
