### PR TITLE
Feature/namespace per tenant

### DIFF
--- a/CNI/romana
+++ b/CNI/romana
@@ -141,9 +141,10 @@ set_up_pod () {
 	NAMESPACE=$(get_args | get_pod_ns)
 	log "--- NAMESPACE = $NAMESPACE ---"
 	KUBEARGS="$KUBEARGS --namespace=$NAMESPACE"
-	TENANT=$( $KUBECTL $KUBEARGS describe pod $POD | get_labels | get_tenant )
-	log "--- TENANT = $TENANT ---"
+#	TENANT=$( $KUBECTL $KUBEARGS describe pod $POD | get_labels | get_tenant )
+#	log "--- TENANT = $TENANT ---"
 	SEGMENT=$( $KUBECTL $KUBEARGS describe pod $POD | get_labels | get_segment )
+	[[ $SEGMENT ]] || SEGMENT="default"
 	log "--- SEGMENT = $SEGMENT ---"
 	NODE=$( $KUBECTL $KUBEARGS get pods -o wide | grep "$POD " | awk '{ print $6 }' )
 	log "--- NODE = $NODE ---"
@@ -154,9 +155,9 @@ set_up_pod () {
 	# Asking romana ipam for an IP address, based on `tenant` label.
 	log "--- PRE-IPAM ---"
 	[[ $SEGMENT ]] || SEGMENT=default
-	IP=$(ipam_allocate_ip $TENANT $SEGMENT $NODE)
+	IP=$(ipam_allocate_ip $NAMESPACE $SEGMENT $NODE)
 	log "--- POST-IPAM IP=$IP---"
-	[[ $IP ]] || die "Failed to allocate IP address for pod $POD on node $NODE with tenant $TENANT" 2
+	[[ $IP ]] || die "Failed to allocate IP address for pod $POD on node $NODE with tenant $NAMESPACE" 2
 
 	# Setting up the networking for Infra namespace
 	sudo ip link add type veth
@@ -174,7 +175,7 @@ set_up_pod () {
 	curl -s -H 'content-type: application/json' -XPOST -d "$(req "veth0-${NSPID}" "$IP" "$NS_ISOLATION")" http://localhost:9604/kubernetes-pod-up 2>&1 >> $LOGFILE
 
 	log "$(req "veth0-${NSPID}" "$IP" "$NS_ISOLATION")"
-	log "--- Setup with infra pod = $POD pid = $PID, PEERIFx = $PEERIFx, PEERIFn=$PEERIFn, TENANT=$TENANT, NODE=$NODE, IP=$IP"
+	log "--- Setup with infra pod = $POD pid = $PID, PEERIFx = $PEERIFx, PEERIFn=$PEERIFn, TENANT=$NAMESPACE, NODE=$NODE, IP=$IP"
 	R=$(result "$IP" "$GATE_MASK")
 	log "$R"
 

--- a/CNI/romana
+++ b/CNI/romana
@@ -44,7 +44,7 @@ IPAM_TYPE="romana-ipam"
 get_pod            () { while read line; do [[ ${line/=*/} == "K8S_POD_NAME" ]] && echo ${line/*=/} || :; done; }
 get_pod_ns         () { while read line; do [[ ${line/=*/} == "K8S_POD_NAMESPACE" ]] && echo ${line/*=/} || :; done; }
 get_tenant         () { while read line; do [[ ${line/=*/} == "owner" ]] && echo ${line/*=/} || :; done; }
-get_segment        () { while read line; do [[ ${line/=*/} == "tier" ]] && echo ${line/*=/} || :; done; }
+get_segment        () { while read line; do [[ ${line/=*/} == "segment" ]] && echo ${line/*=/} || :; done; }
 get_labels         () { awk '/Labels/ { print $2}' | xargs -d"," -n1 ; } 
 get_json_kv        () { sed 's/["{}]//g' | xargs -d "," -n1; }
 get_ip             () { while read line; do [[ ${line/:*/} == "ip" ]] && echo ${line/*:/} || :; done; }

--- a/NetworkPolicy/k8s-listener.py
+++ b/NetworkPolicy/k8s-listener.py
@@ -344,10 +344,10 @@ def parse_rule_specs(obj):
     """
     try:
         rule = {}
-        rule["src_tenant"] = obj["object"]["metadata"]["labels"]["owner"]
+        rule["src_tenant"] = obj["object"]["metadata"]["namespace"]
         rule["dst_tenant"] = rule["src_tenant"]
-        rule["dst_segment"] = obj["object"]["spec"]["podSelector"]["tier"]
-        rule["src_segment"] = obj["object"]["spec"]["allowIncoming"]["from"][0]["pods"]["tier"]
+        rule["dst_segment"] = obj["object"]["spec"]["podSelector"]["segment"]
+        rule["src_segment"] = obj["object"]["spec"]["allowIncoming"]["from"][0]["pods"]["segment"]
         rule["port"] = obj["object"]["spec"]["allowIncoming"]["toPorts"][0]["port"]
         rule["protocol"] = obj["object"]["spec"]["allowIncoming"]["toPorts"][0]["protocol"]
         return rule


### PR DESCRIPTION
- 1:1 mapping between kube namespaces and romana tenants
- tiers renamed back to segments
- owners deprecated 
- default segment called `default`

this PR depends on https://github.com/romana/romana/pull/81
