### PR TITLE
Ipam allocate endpoints

### DIFF
--- a/CNI/romana
+++ b/CNI/romana
@@ -127,7 +127,7 @@ ipam_allocate_ip () {
 	tenant=$1
 	segment=$2
 	node=$3
-	IP=$(curl -s "http://$ROMANA_MASTER_IP:9601/allocateIpByName?tenantName=${tenant}&segmentName=${segment}&hostName=${node}&instanceId=0" | get_json_kv | get_ip)
+	IP=$(curl -s "http://$ROMANA_MASTER_IP:9601/allocateIP?tenantName=${tenant}&segmentName=${segment}&hostName=${node}" | get_json_kv | get_ip)
 	echo $IP
 }
 

--- a/CNI/romana
+++ b/CNI/romana
@@ -127,7 +127,7 @@ ipam_allocate_ip () {
 	tenant=$1
 	segment=$2
 	node=$3
-	IP=$(curl -s "http://$ROMANA_MASTER_IP:9601/allocateIP?clusterType=kubernetes&tenantName=${tenant}&segmentName=${segment}&hostName=${node}" | get_json_kv | get_ip)
+	IP=$(curl -s "http://$ROMANA_MASTER_IP:9601/allocateIP?tenantName=${tenant}&segmentName=${segment}&hostName=${node}" | get_json_kv | get_ip)
 	echo $IP
 }
 

--- a/CNI/romana
+++ b/CNI/romana
@@ -127,7 +127,7 @@ ipam_allocate_ip () {
 	tenant=$1
 	segment=$2
 	node=$3
-	IP=$(curl -s "http://$ROMANA_MASTER_IP:9601/allocateIP?tenantName=${tenant}&segmentName=${segment}&hostName=${node}" | get_json_kv | get_ip)
+	IP=$(curl -s "http://$ROMANA_MASTER_IP:9601/allocateIP?clusterType=kubernetes&tenantName=${tenant}&segmentName=${segment}&hostName=${node}" | get_json_kv | get_ip)
 	echo $IP
 }
 


### PR DESCRIPTION
Change CNI to use new URL endpoint, and include clusterType=kubernetes in URL query parameters.
Relates to romana/core#85.
