### PR TITLE
Fix pod label extraction

### DIFF
--- a/CNI/romana
+++ b/CNI/romana
@@ -150,8 +150,14 @@ set_up_pod () {
 	log "--- SEGMENT = $SEGMENT ---"
 	NODE=$( $KUBECTL $KUBEARGS get pod "$POD" -o json | jq -r '.spec.nodeName')
 	log "--- NODE = $NODE ---"
-	NS_ISOLATION=$( $KUBECTL $KUBEARGS get namespace $NAMESPACE -o json | jq -r '.metadata.annotations["net.alpha.kubernetes.io/network-isolation"]' )
-	[[ $NS_ISOLATION != "on" ]] && NS_ISOLATION="off"
+	NS_ISOLATION="off"
+	NS_POLICY=$( $KUBECTL $KUBEARGS get namespace $NAMESPACE -o json | jq -r '.metadata.annotations["net.beta.kubernetes.io/networkpolicy"] // empty')
+	if [[ "$NS_POLICY" ]]; then
+		INGRESS_ISOLATION=$(jq -r '.ingress.isolation // empty' <<< "$NS_POLICY")
+		if [[ "$INGRESS_ISOLATION" = "DefaultDeny" ]]; then
+			NS_ISOLATION="on"
+		fi
+	fi
 	log "--- NS_ISOLATION = $NS_ISOLATION ---"
 
 	# Ensure segment exists

--- a/CNI/romana
+++ b/CNI/romana
@@ -45,8 +45,6 @@ ROMANA_CLI="romana"
 get_pod            () { while read line; do [[ ${line/=*/} == "K8S_POD_NAME" ]] && echo ${line/*=/} || :; done; }
 get_pod_ns         () { while read line; do [[ ${line/=*/} == "K8S_POD_NAMESPACE" ]] && echo ${line/*=/} || :; done; }
 get_tenant         () { while read line; do [[ ${line/=*/} == "owner" ]] && echo ${line/*=/} || :; done; }
-get_segment        () { while read line; do [[ ${line/=*/} == "segment" ]] && echo ${line/*=/} || :; done; }
-get_labels         () { awk '/Labels/ { print $2}' | xargs -d"," -n1 ; } 
 get_json_kv        () { sed 's/["{}]//g' | xargs -d "," -n1; }
 get_ip             () { while read line; do [[ ${line/:*/} == "ip" ]] && echo ${line/*:/} || :; done; }
 get_nspid          () { echo $1 | awk -F"/" '{ print $3 }'; }
@@ -147,10 +145,10 @@ set_up_pod () {
 	KUBEARGS="$KUBEARGS --namespace=$NAMESPACE"
 #	TENANT=$( $KUBECTL $KUBEARGS describe pod $POD | get_labels | get_tenant )
 #	log "--- TENANT = $TENANT ---"
-	SEGMENT=$( $KUBECTL $KUBEARGS describe pod $POD | get_labels | get_segment )
+	SEGMENT=$( $KUBECTL $KUBEARGS get pod $POD -o json | jq -r 'if .metadata.labels["segment"] then .metadata.labels["segment"] else empty end')
 	[[ $SEGMENT ]] || SEGMENT="default"
 	log "--- SEGMENT = $SEGMENT ---"
-	NODE=$( $KUBECTL $KUBEARGS get pods -o wide | grep "$POD " | awk '{ print $6 }' )
+	NODE=$( $KUBECTL $KUBEARGS get pod "$POD" -o json | jq -r '.spec.nodeName')
 	log "--- NODE = $NODE ---"
 	NS_ISOLATION=$( $KUBECTL $KUBEARGS get namespace $NAMESPACE -o json | jq -r '.metadata.annotations["net.alpha.kubernetes.io/network-isolation"]' )
 	[[ $NS_ISOLATION != "on" ]] && NS_ISOLATION="off"

--- a/CNI/romana
+++ b/CNI/romana
@@ -151,10 +151,14 @@ set_up_pod () {
 	NODE=$( $KUBECTL $KUBEARGS get pod "$POD" -o json | jq -r '.spec.nodeName')
 	log "--- NODE = $NODE ---"
 	NS_ISOLATION="off"
+	# The metadata value for isolation is now a JSON object. Since we ask kubectl to give us namespace data in JSON, we need two steps to extract it.
+	# Extract the network policy from the namespace annotation. Capture the value.
 	NS_POLICY=$( $KUBECTL $KUBEARGS get namespace $NAMESPACE -o json | jq -r '.metadata.annotations["net.beta.kubernetes.io/networkpolicy"] // empty')
 	if [[ "$NS_POLICY" ]]; then
+		# We have a value. Try to extract the ingress -> isolation field.
 		INGRESS_ISOLATION=$(jq -r '.ingress.isolation // empty' <<< "$NS_POLICY")
 		if [[ "$INGRESS_ISOLATION" = "DefaultDeny" ]]; then
+			# Field was present and matched the known "DefaultDeny" value. Enable isolation.
 			NS_ISOLATION="on"
 		fi
 	fi

--- a/CNI/romana
+++ b/CNI/romana
@@ -184,7 +184,7 @@ set_up_pod () {
 
 	log "$(req "veth0-${NSPID}" "$IP" "$NS_ISOLATION")"
 	# Romana agent does the rest (endpoint route and firewall)
-	curl -s -H 'content-type: application/json' -XPOST -d "$(req "veth0-${NSPID}" "$IP" "$NS_ISOLATION")" http://localhost:9604/kubernetes-pod-up 2>&1 >> $LOGFILE
+	curl -s -H 'content-type: application/json' -XPOST -d "$(req "veth0-${NSPID}" "$IP" "$NS_ISOLATION")" http://localhost:9604/pod 2>&1 >> $LOGFILE
 
 	log "$(req "veth0-${NSPID}" "$IP" "$NS_ISOLATION")"
 	log "--- Setup with infra pod = $POD pid = $PID, PEERIFx = $PEERIFx, PEERIFn=$PEERIFn, TENANT=$NAMESPACE, NODE=$NODE, IP=$IP"


### PR DESCRIPTION
Minor fixes to satisfy kubernetes 1.3.
- The format for labels was different (multi-line), so using json / jq instead.
- Isolation is a field within a json value in the annotation. So extracting the JSON, then the field from it to see if it matches `DefaultDeny`
- Agent endpoint is now `/pod`
