### PR TITLE
Ensure independent CNI actions

### DIFF
--- a/CNI/romana
+++ b/CNI/romana
@@ -183,9 +183,7 @@ set_up_pod () {
 	[[ $IP ]] || die "Failed to allocate IP address for pod $POD on node $NODE with tenant $NAMESPACE" 2
 
 	# Setting up the networking for Infra namespace
-	sudo ip link add type veth
-	sudo ip link set veth0 name "veth0-${NSPID}"
-	sudo ip link set veth1 name "veth1-${NSPID}"
+	sudo ip link add "veth0-${NSPID}" type veth peer name "veth1-${NSPID}"
 	sudo ip link set "veth1-${NSPID}" netns ${NSPID}
 	sudo nsenter -t ${NSPID} -n ip link set "veth1-${NSPID}" name eth0
 	sudo nsenter -t ${NSPID} -n ip link set eth0 up


### PR DESCRIPTION
When creating lots of pods, eg: `kubectl run --image=cirros --replicas=24 dozens`, some pods had incomplete network setup and were not reachable.

This is because the CNI script is being executed by kubectl in parallel and veth names get automatically assigned.
Eg:
pod1 CNI had created veth0 and vet1.
pod2 CNI is executing the veth creation step, expecting veth0 and veth1 but actually got veth2 and veth3. The following steps fail.

By providing names that include the NSPID when creating the veth pair, the problem is avoided.
